### PR TITLE
Handle trailing '/' in map path

### DIFF
--- a/synergine2_cocos2d/util.py
+++ b/synergine2_cocos2d/util.py
@@ -10,7 +10,8 @@ from synergine2_cocos2d.exception import FileNotFound
 
 def get_map_file_path_from_dir(map_dir_path: str) -> str:
     # TODO: path is temp here
-    return '{}.tmx'.format(os.path.join(map_dir_path, os.path.basename(map_dir_path)))
+    return '{}.tmx'.format(os.path.join(map_dir_path,
+        os.path.basename(map_dir_path.rstrip('/'))))
 
 
 class PathManager(object):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -5,7 +5,8 @@ import pytest
 
 from synergine2.utils import ChunkManager
 from synergine2_cocos2d.exception import FileNotFound
-from synergine2_cocos2d.util import PathManager,get_map_file_path_from_dir
+from synergine2_cocos2d.util import PathManager
+from synergine2_cocos2d.util import get_map_file_path_from_dir
 from tests import BaseTest
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -5,7 +5,7 @@ import pytest
 
 from synergine2.utils import ChunkManager
 from synergine2_cocos2d.exception import FileNotFound
-from synergine2_cocos2d.util import PathManager
+from synergine2_cocos2d.util import PathManager,get_map_file_path_from_dir
 from tests import BaseTest
 
 
@@ -44,3 +44,7 @@ class TestUtils(BaseTest):
         path_manager.add_included_path('tests/fixtures/some_media2')
         # it is prior on path finding
         assert 'tests/fixtures/some_media2/foo.txt' == path_manager.path('foo.txt')
+
+    def test_get_map_file_path_from_dir(self):
+        assert get_map_file_path_from_dir('map/003') == 'map/003/003.tmx'
+        assert get_map_file_path_from_dir('map/003/') == 'map/003/003.tmx'


### PR DESCRIPTION
os.path.basename('path/') returns '' so strip the trailing '/' first. I discovered this special case when I used tab to complete the map path on the command line. :)